### PR TITLE
feat: install/init/start sandbox from rust

### DIFF
--- a/crate/.gitignore
+++ b/crate/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "near-sandbox"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+binary-install = "0.0.2"
+hex = "0.3"
+home = "0.5.3"
+siphasher = "0.2.3"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.43"
 binary-install = "0.0.2"
 hex = "0.3"
 home = "0.5.3"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "near-sandbox"
+name = "near-sandbox-utils"
 version = "0.1.0"
 edition = "2018"
 

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,3 +8,6 @@ binary-install = "0.0.2"
 hex = "0.3"
 home = "0.5.3"
 siphasher = "0.2.3"
+
+[features]
+global_install = []

--- a/crate/build.rs
+++ b/crate/build.rs
@@ -1,0 +1,3 @@
+// HACK: need this build script so that env var OUT_DIR gets set:
+// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+fn main() {}

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -6,7 +6,6 @@ use binary_install::Cache;
 use siphasher::sip::SipHasher13;
 use std::hash::{Hash, Hasher};
 
-
 #[cfg(target_os = "linux")]
 const fn platform() -> &'static str {
     "Linux"
@@ -52,9 +51,13 @@ fn bin_url() -> String {
 }
 
 fn download_path() -> PathBuf {
-    let mut buf = home::home_dir().expect("could not retrieve home_dir");
-    buf.push(".near");
-    buf
+    if cfg!(features = "global_install") {
+        let mut buf = home::home_dir().expect("could not retrieve home_dir");
+        buf.push(".near");
+        buf
+    } else {
+        PathBuf::from(env!("OUT_DIR"))
+    }
 }
 
 /// Returns a path to the binary in the form of {home}/.near/near-sandbox-{hash}/near-sandbox

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,10 +1,11 @@
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
+use std::hash::{Hash, Hasher};
 
+use anyhow::anyhow;
 use binary_install::Cache;
 use siphasher::sip::SipHasher13;
-use std::hash::{Hash, Hasher};
 
 const fn platform() -> &'static str {
     #[cfg(target_os = "linux")]
@@ -70,7 +71,7 @@ pub fn bin_path() -> PathBuf {
     buf
 }
 
-pub fn install() -> io::Result<PathBuf> {
+pub fn install() -> anyhow::Result<PathBuf> {
     println!("Installing near-sandbox into {}", bin_path().to_str().unwrap());
     let dl_cache = Cache::at(&download_path());
     let dl = dl_cache.download(
@@ -79,11 +80,11 @@ pub fn install() -> io::Result<PathBuf> {
         &["near-sandbox"],
         &bin_url(),
     )
-    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
-    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("Unable to download near-sandbox")))?;
+    .map_err(|e| anyhow::Error::msg(e))?
+    .ok_or_else(|| anyhow!("Could not install near-sandbox"))?;
 
     dl.binary("near-sandbox")
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        .map_err(|e| anyhow::Error::msg(e))
 }
 
 pub fn ensure_sandbox_bin() -> io::Result<PathBuf> {

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -41,7 +41,7 @@ fn hashed_dirname(url: &str, name: &str) -> String {
 
 fn bin_url() -> String {
     format!(
-        "https://cloudflare-ipfs.com/ipfs/QmZ6MQ9VMxBcahcmJZdfvUAbyQpjnbHa9ixbqnMTq2k8FG/{}-near-sandbox.tar.gz",
+        "https://ipfs.io/ipfs/QmZ6MQ9VMxBcahcmJZdfvUAbyQpjnbHa9ixbqnMTq2k8FG/{}-near-sandbox.tar.gz",
         platform(),
     )
 }
@@ -71,7 +71,6 @@ pub fn bin_path() -> PathBuf {
 }
 
 pub fn install() -> anyhow::Result<PathBuf> {
-    println!("Installing near-sandbox into {}", bin_path().to_str().unwrap());
     let dl_cache = Cache::at(&download_path());
     let dl = dl_cache.download(
         true,
@@ -90,6 +89,7 @@ pub fn ensure_sandbox_bin() -> anyhow::Result<PathBuf> {
     let mut bin_path = bin_path();
     if !bin_path.exists() {
         bin_path = install()?;
+        println!("Installed near-sandbox into {}", bin_path.to_str().unwrap());
         std::env::set_var("NEAR_SANDBOX_BIN_PATH", bin_path.as_os_str());
     }
     Ok(bin_path)

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,0 +1,136 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+
+use binary_install::Cache;
+use siphasher::sip::SipHasher13;
+use std::hash::{Hash, Hasher};
+
+
+#[cfg(target_os = "linux")]
+const fn platform() -> &'static str {
+    "Linux"
+}
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const fn platform() -> &'static str {
+    "Darwin"
+}
+
+#[cfg(all(not(all(target_os = "macos", target_arch = "x86_64")), not(target_os = "linux")))]
+const fn platform() -> &'static str {
+    compile_error!("Unsupported platform");
+}
+
+fn local_rpc_addr(port: u16) -> String {
+    format!("0.0.0.0:{}", port)
+}
+
+// HACK: Taken from binary-install to get generated temp_dir generated
+fn hashed_dirname(url: &str, name: &str) -> String {
+    let mut hasher = SipHasher13::new();
+    url.hash(&mut hasher);
+    let result = hasher.finish();
+    let hex = hex::encode(&[
+        (result >> 0) as u8,
+        (result >> 8) as u8,
+        (result >> 16) as u8,
+        (result >> 24) as u8,
+        (result >> 32) as u8,
+        (result >> 40) as u8,
+        (result >> 48) as u8,
+        (result >> 56) as u8,
+    ]);
+    format!("{}-{}", name, hex)
+}
+
+
+fn bin_url() -> String {
+    format!(
+        "https://cloudflare-ipfs.com/ipfs/QmZ6MQ9VMxBcahcmJZdfvUAbyQpjnbHa9ixbqnMTq2k8FG/{}-near-sandbox.tar.gz",
+        platform(),
+    )
+}
+
+fn download_path() -> PathBuf {
+    let mut buf = std::env::temp_dir();
+    buf.push("near");
+    buf
+}
+
+pub fn bin_path() -> io::Result<PathBuf> {
+    if let Ok(path) = std::env::var("NEAR_SANDBOX_BIN_PATH") {
+        return Ok(PathBuf::from(path));
+    }
+
+    let mut buf = download_path();
+    buf.push(hashed_dirname(&bin_url(), "near-sandbox"));
+    buf.push("near-sandbox");
+    std::env::set_var("NEAR_SANDBOX_BIN_PATH", buf.as_os_str());
+
+    Ok(buf)
+}
+
+pub fn install() -> io::Result<PathBuf> {
+    let dl_cache = Cache::at(&download_path());
+    let dl = dl_cache.download(
+        true,
+        "near-sandbox",
+        &["near-sandbox"],
+        &bin_url(),
+    )
+    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, format!("Unable to download near-sandbox")))?;
+
+    dl.binary("near-sandbox")
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+}
+
+pub fn ensure_sandbox_bin() -> io::Result<PathBuf> {
+    let mut bin_path = bin_path()?;
+    if !bin_path.exists() {
+        bin_path = install()?;
+        std::env::set_var("NEAR_SANDBOX_BIN_PATH", bin_path.as_os_str());
+    }
+    Ok(bin_path)
+}
+
+pub fn start(home_dir: impl AsRef<Path>, port: u16) -> io::Result<Child> {
+    let bin_path = ensure_sandbox_bin()?;
+    let home_dir = home_dir.as_ref().to_str().unwrap();
+    if cfg!(target_os = "windows") {
+        Command::new(bin_path)
+            .args(&[
+                "--home",
+                home_dir,
+                "run",
+                "--rpc-addr",
+                &local_rpc_addr(port),
+            ])
+            .spawn()
+    } else {
+        Command::new(bin_path)
+            .arg("--home")
+            .arg(home_dir)
+            .arg("run")
+            .arg("--rpc-addr")
+            .arg(&local_rpc_addr(port))
+            .spawn()
+    }
+}
+
+pub fn init(home_dir: impl AsRef<Path>) -> io::Result<Child> {
+    let bin_path = ensure_sandbox_bin()?;
+    let home_dir = home_dir.as_ref().to_str().unwrap();
+    if cfg!(target_os = "windows") {
+        Command::new(bin_path)
+            .args(&["--home", home_dir, "init"])
+            .spawn()
+    } else {
+        Command::new(bin_path)
+            .arg("--home")
+            .arg(home_dir)
+            .arg("init")
+            .spawn()
+    }
+}

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -6,18 +6,14 @@ use binary_install::Cache;
 use siphasher::sip::SipHasher13;
 use std::hash::{Hash, Hasher};
 
-#[cfg(target_os = "linux")]
 const fn platform() -> &'static str {
-    "Linux"
-}
+    #[cfg(target_os = "linux")]
+    return "Linux";
 
-#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-const fn platform() -> &'static str {
-    "Darwin"
-}
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    return "Darwin";
 
-#[cfg(all(not(all(target_os = "macos", target_arch = "x86_64")), not(target_os = "linux")))]
-const fn platform() -> &'static str {
+    #[cfg(all(not(all(target_os = "macos", target_arch = "x86_64")), not(target_os = "linux")))]
     compile_error!("Unsupported platform");
 }
 


### PR DESCRIPTION
Installs sandbox binary during runtime/test-time, to the following path format `{home}/.near/near-sandbox-{hash}/near-sandbox`