### PR TITLE
Let user to specify binary download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ If you want to run NEAR Sandbox on its own, continue reading.
 
     npm i -g near-sandbox
 
+Note: If you have trouble downloading binary from IPFS gateway, you can upload a pre-built near-sandbox tar file to any file storage service and use `SANDBOX_ARTIFACT_URL` environment variable to specify it's base URL.      
+e.g. `> SANDBOX_ARTIFACT_URL=https://s3.aws.com/my-binary npm i near-sandbox`
+
+
 ### With Rust
 
 Coming soon

--- a/npm/getBinary.js
+++ b/npm/getBinary.js
@@ -20,7 +20,8 @@ function getPlatform() {
 function getBinary() {
     const platform = getPlatform();
     const version = require('./package.json').version;
-    const url = `https://ipfs.io/ipfs/QmZ6MQ9VMxBcahcmJZdfvUAbyQpjnbHa9ixbqnMTq2k8FG/${ platform }-near-sandbox.tar.gz`;
+    const baseUrl = process.env.SANDBOX_ARTIFACT_URL || 'https://ipfs.io/ipfs/QmZ6MQ9VMxBcahcmJZdfvUAbyQpjnbHa9ixbqnMTq2k8FG';
+    const url = `${baseUrl}/${ platform }-near-sandbox.tar.gz`;
     const name = 'near-sandbox';
     return new Binary(name, url);
 }


### PR DESCRIPTION
Raised this PR because I wanna to use runner-js and had hard time to download the required binary file.

At first IPFS gateway timed out every time, so I tried to upload the binary to github repo and replaced the url link with github raw content one. However since I'm from China, github link also is not accessible by Axios without setting up a VPN proxy :(. So finally I have to upload it to AWS s3 and it eventually worked for me.

Thus I would suggest to expose this environ so that users won't need to change the code and do lots of npm links to get around this issue.