### PR TITLE
bugfix: avoid corrupting binaries near-sandbox binaries with different temp paths

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -11,9 +11,9 @@ Utility library for launching NEAR sandbox environments.
 [dependencies]
 anyhow = "1"
 binary-install = "0.0.2"
+chrono = "0.4"
 hex = "0.3"
 home = "0.5.3"
-siphasher = "0.2.3"
 
 [features]
 global_install = []


### PR DESCRIPTION
This will fix binaries from being corrupted from calling into `install`s concurrently. Different temp installation folders were added so that bytes weren't being written into the same one used for downloading. This solution was simpler thank a lockfile since that would've required some more complexity than I would've liked. 