### PR TITLE
release(crate): 0.1.1

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION
after this, will release 0.1.1 for `near-sandbox-utils` crate