### PR TITLE
feat(crate): Add in environment variables to control binary log output

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -120,5 +120,8 @@ fn log_vars() -> Vec<(String, String)> {
     if let Ok(val) = std::env::var("NEAR_SANDBOX_LOG") {
         vars.push(("RUST_LOG".into(), val));
     }
+    if let Ok(val) = std::env::var("NEAR_SANDBOX_LOG_STYLE") {
+        vars.push(("RUST_LOG_STYLE".into(), val));
+    }
     vars
 }

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -87,7 +87,7 @@ pub fn run_with_options(options: &[&str]) -> anyhow::Result<Child> {
     let bin_path = ensure_sandbox_bin()?;
     Command::new(bin_path)
         .args(options)
-        .envs(std::env::vars())
+        .envs(log_vars())
         .spawn()
         .map_err(Into::into)
 }
@@ -109,8 +109,16 @@ pub fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
     let bin_path = ensure_sandbox_bin()?;
     let home_dir = home_dir.as_ref().to_str().unwrap();
     Command::new(bin_path)
-        .envs(std::env::vars())
+        .envs(log_vars())
         .args(&["--home", home_dir, "init"])
         .spawn()
         .map_err(Into::into)
+}
+
+fn log_vars() -> Vec<(String, String)> {
+    let mut vars = Vec::new();
+    if let Ok(val) = std::env::var("NEAR_SANDBOX_LOG") {
+        vars.push(("RUST_LOG".into(), val));
+    }
+    vars
 }

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -85,19 +85,11 @@ pub fn ensure_sandbox_bin() -> anyhow::Result<PathBuf> {
 
 pub fn run_with_options(options: &[&str]) -> anyhow::Result<Child> {
     let bin_path = ensure_sandbox_bin()?;
-    if cfg!(target_os = "windows") {
-        Command::new(bin_path)
-            .args(options)
-            .spawn()
-            .map_err(Into::into)
-    } else {
-        let mut cmd = Command::new(bin_path);
-        for arg in options {
-            cmd.arg(arg);
-        }
-
-        cmd.spawn().map_err(Into::into)
-    }
+    Command::new(bin_path)
+        .args(options)
+        .envs(std::env::vars())
+        .spawn()
+        .map_err(Into::into)
 }
 
 pub fn run(home_dir: impl AsRef<Path>, rpc_port: u16, network_port: u16) -> anyhow::Result<Child> {
@@ -116,17 +108,9 @@ pub fn run(home_dir: impl AsRef<Path>, rpc_port: u16, network_port: u16) -> anyh
 pub fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
     let bin_path = ensure_sandbox_bin()?;
     let home_dir = home_dir.as_ref().to_str().unwrap();
-    if cfg!(target_os = "windows") {
-        Command::new(bin_path)
-            .args(&["--home", home_dir, "init"])
-            .spawn()
-            .map_err(Into::into)
-    } else {
-        Command::new(bin_path)
-            .arg("--home")
-            .arg(home_dir)
-            .arg("init")
-            .spawn()
-            .map_err(Into::into)
-    }
+    Command::new(bin_path)
+        .envs(std::env::vars())
+        .args(&["--home", home_dir, "init"])
+        .spawn()
+        .map_err(Into::into)
 }


### PR DESCRIPTION
This adds a custom environment variable `NEAR_SANDBOX_LOG` to control log output of the sandbox binary which allows `workspaces-rs` to suppress logs going forward. This isn't exposing `RUST_LOG` to be used externally due to potentially conflicting with log targets that are potentially common such as `stats` from nearcore, which could end up as footgun.

Also, cleaned up some of the internal `target_os` command code since that seems to be consistent now.