### PR TITLE
update: sandbox binary hash

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -6,7 +6,7 @@ use binary_install::Cache;
 use chrono::Utc;
 
 /// The commit hash on nearcore that we want to point to, to retrieve the sandbox binary:
-const COMMIT: &str = "2c9375ee5ee307c2ce870c7dbd25eefd84fe8c36";
+const COMMIT: &str = "4038f249bcc58abf52db117df6f40cd25504d118";
 
 const fn platform() -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -15,7 +15,10 @@ const fn platform() -> &'static str {
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     return "Darwin-x86_64";
 
-    #[cfg(all(not(all(target_os = "macos", target_arch = "x86_64")), not(all(target_os = "linux", target_arch = "x86_64"))))]
+    #[cfg(all(
+        not(all(target_os = "macos", target_arch = "x86_64")),
+        not(all(target_os = "linux", target_arch = "x86_64"))
+    ))]
     compile_error!("Unsupported platform");
 }
 
@@ -58,17 +61,12 @@ pub fn install() -> anyhow::Result<PathBuf> {
     // Download binary into temp dir
     let tmp_dir = format!("near-sandbox-{}", Utc::now());
     let dl_cache = Cache::at(&download_path());
-    let dl = dl_cache.download(
-        true,
-        &tmp_dir,
-        &["near-sandbox"],
-        &bin_url(),
-    )
-    .map_err(anyhow::Error::msg)?
-    .ok_or_else(|| anyhow!("Could not install near-sandbox"))?;
+    let dl = dl_cache
+        .download(true, &tmp_dir, &["near-sandbox"], &bin_url())
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| anyhow!("Could not install near-sandbox"))?;
 
-    let path = dl.binary("near-sandbox")
-        .map_err(anyhow::Error::msg)?;
+    let path = dl.binary("near-sandbox").map_err(anyhow::Error::msg)?;
 
     // Move near-sandbox binary to correct location from temp folder.
     let dest = download_path().join("near-sandbox");

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -5,6 +5,9 @@ use anyhow::anyhow;
 use binary_install::Cache;
 use chrono::Utc;
 
+/// The commit hash on nearcore that we want to point to, to retrieve the sandbox binary:
+const COMMIT: &str = "5bc89098a20fb580b97bb56b6711b5ca2a86a4c3";
+
 const fn platform() -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     return "Linux-x86_64";
@@ -22,8 +25,9 @@ fn local_addr(port: u16) -> String {
 
 fn bin_url() -> String {
     format!(
-        "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/{}/master/2c9375ee5ee307c2ce870c7dbd25eefd84fe8c36/near-sandbox.tar.gz",
+        "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/{}/master/{}/near-sandbox.tar.gz",
         platform(),
+        COMMIT,
     )
 }
 

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -6,7 +6,7 @@ use binary_install::Cache;
 use chrono::Utc;
 
 /// The commit hash on nearcore that we want to point to, to retrieve the sandbox binary:
-const COMMIT: &str = "5bc89098a20fb580b97bb56b6711b5ca2a86a4c3";
+const COMMIT: &str = "2c9375ee5ee307c2ce870c7dbd25eefd84fe8c36";
 
 const fn platform() -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]


### PR DESCRIPTION
Adjusted the commit hash to point to latest nearcore for the newest sandbox binary, which contains fast-forwarding