### PR TITLE
release(crate): 0.1.2 sandbox crate release

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION
Newest patch release includes environment variables to allow configuring the sandbox binary's logs