### PR TITLE
feat: support async calls for the rust crate

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,6 +10,7 @@ Utility library for launching NEAR sandbox environments.
 
 [dependencies]
 anyhow = "1"
+async-process = "1.3.0"
 binary-install = "0.0.2"
 chrono = "0.4"
 hex = "0.3"

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -12,7 +12,10 @@ const fn platform() -> &'static str {
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     return "Darwin-x86_64";
 
-    #[cfg(all(not(all(target_os = "macos", target_arch = "x86_64")), not(all(target_os = "linux", target_arch = "x86_64"))))]
+    #[cfg(all(
+        not(all(target_os = "macos", target_arch = "x86_64")),
+        not(all(target_os = "linux", target_arch = "x86_64"))
+    ))]
     compile_error!("Unsupported platform");
 }
 
@@ -54,17 +57,12 @@ pub fn install() -> anyhow::Result<PathBuf> {
     // Download binary into temp dir
     let tmp_dir = format!("near-sandbox-{}", Utc::now());
     let dl_cache = Cache::at(&download_path());
-    let dl = dl_cache.download(
-        true,
-        &tmp_dir,
-        &["near-sandbox"],
-        &bin_url(),
-    )
-    .map_err(anyhow::Error::msg)?
-    .ok_or_else(|| anyhow!("Could not install near-sandbox"))?;
+    let dl = dl_cache
+        .download(true, &tmp_dir, &["near-sandbox"], &bin_url())
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| anyhow!("Could not install near-sandbox"))?;
 
-    let path = dl.binary("near-sandbox")
-        .map_err(anyhow::Error::msg)?;
+    let path = dl.binary("near-sandbox").map_err(anyhow::Error::msg)?;
 
     // Move near-sandbox binary to correct location from temp folder.
     let dest = download_path().join("near-sandbox");

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -96,7 +96,7 @@ pub fn ensure_sandbox_bin() -> anyhow::Result<PathBuf> {
     Ok(bin_path)
 }
 
-pub async fn run_with_options(options: &[&str]) -> anyhow::Result<Child> {
+pub fn run_with_options(options: &[&str]) -> anyhow::Result<Child> {
     let bin_path = crate::ensure_sandbox_bin()?;
     Command::new(bin_path)
         .args(options)
@@ -105,11 +105,7 @@ pub async fn run_with_options(options: &[&str]) -> anyhow::Result<Child> {
         .map_err(Into::into)
 }
 
-pub async fn run(
-    home_dir: impl AsRef<Path>,
-    rpc_port: u16,
-    network_port: u16,
-) -> anyhow::Result<Child> {
+pub fn run(home_dir: impl AsRef<Path>, rpc_port: u16, network_port: u16) -> anyhow::Result<Child> {
     let home_dir = home_dir.as_ref().to_str().unwrap();
     run_with_options(&[
         "--home",
@@ -120,10 +116,9 @@ pub async fn run(
         "--network-addr",
         &local_addr(network_port),
     ])
-    .await
 }
 
-pub async fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
+pub fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
     let bin_path = ensure_sandbox_bin()?;
     let home_dir = home_dir.as_ref().to_str().unwrap();
     Command::new(bin_path)

--- a/crate/src/sync.rs
+++ b/crate/src/sync.rs
@@ -1,0 +1,34 @@
+use std::path::Path;
+use std::process::{Child, Command};
+
+pub fn run_with_options(options: &[&str]) -> anyhow::Result<Child> {
+    let bin_path = crate::ensure_sandbox_bin()?;
+    Command::new(bin_path)
+        .args(options)
+        .envs(crate::log_vars())
+        .spawn()
+        .map_err(Into::into)
+}
+
+pub fn run(home_dir: impl AsRef<Path>, rpc_port: u16, network_port: u16) -> anyhow::Result<Child> {
+    let home_dir = home_dir.as_ref().to_str().unwrap();
+    run_with_options(&[
+        "--home",
+        home_dir,
+        "run",
+        "--rpc-addr",
+        &crate::local_addr(rpc_port),
+        "--network-addr",
+        &crate::local_addr(network_port),
+    ])
+}
+
+pub fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
+    let bin_path = crate::ensure_sandbox_bin()?;
+    let home_dir = home_dir.as_ref().to_str().unwrap();
+    Command::new(bin_path)
+        .envs(crate::log_vars())
+        .args(&["--home", home_dir, "init"])
+        .spawn()
+        .map_err(Into::into)
+}


### PR DESCRIPTION
Fixes #29 

Decided to move sync functions to a separate module and expose async ones by default since this seems to be a common practice in Rust crates. Also, because you can't create a module named `async` :)