### PR TITLE
feat(crate): Allow sandbox version configuration

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -79,6 +79,8 @@ pub fn install_with_version(version: &str) -> anyhow::Result<PathBuf> {
     Ok(dest)
 }
 
+/// Installs sandbox node with the default version. This is a version that is usually stable
+/// and has landed into mainnet to reflect the latest stable features and fixes.
 pub fn install() -> anyhow::Result<PathBuf> {
     install_with_version(DEFAULT_SANDBOX_COMMIT_HASH)
 }


### PR DESCRIPTION
This is a simple change for now, but with https://github.com/near/workspaces-rs/issues/88, I can see us adding in builders in the future to do a lot of this configuration which could specify the download path and version, with potentially more to come.