### PR TITLE
release(0.2) crate and release(0.0.9) npm package

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 
 // The current version of the sandbox node we want to point to. This can be updated from
 // time to time, but probably should be close to when a release is made.
-const DEFAULT_SANDBOX_COMMIT_HASH: &str = "2c9375ee5ee307c2ce870c7dbd25eefd84fe8c36";
+const DEFAULT_SANDBOX_COMMIT_HASH: &str = "1.25.0/9b3d6ba551f561a028f0216051e031bc2ba0c6b7";
 
 const fn platform() -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -29,7 +29,7 @@ fn local_addr(port: u16) -> String {
 
 fn bin_url(version: &str) -> String {
     format!(
-        "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/{}/master/{}/near-sandbox.tar.gz",
+        "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/{}/{}/near-sandbox.tar.gz",
         platform(),
         version,
     )

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 
 // The current version of the sandbox node we want to point to. This can be updated from
 // time to time, but probably should be close to when a release is made.
-const DEFAULT_SANDBOX_COMMIT_HASH: &str = "1.25.0/9b3d6ba551f561a028f0216051e031bc2ba0c6b7";
+const DEFAULT_SANDBOX_COMMIT_HASH: &str = "master/57362268301554563c4f800af963a1270b3d5283";
 
 const fn platform() -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/npm/dist/getBinary.js
+++ b/npm/dist/getBinary.js
@@ -14,7 +14,7 @@ function getPlatform() {
 }
 function AWSUrl() {
     const [platform, arch] = getPlatform();
-    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.25.0/9b3d6ba551f561a028f0216051e031bc2ba0c6b7/near-sandbox.tar.gz`;
+    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/57362268301554563c4f800af963a1270b3d5283/near-sandbox.tar.gz`;
 }
 exports.AWSUrl = AWSUrl;
 function getBinary(name = "near-sandbox") {

--- a/npm/dist/getBinary.js
+++ b/npm/dist/getBinary.js
@@ -14,7 +14,7 @@ function getPlatform() {
 }
 function AWSUrl() {
     const [platform, arch] = getPlatform();
-    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/2c9375ee5ee307c2ce870c7dbd25eefd84fe8c36/near-sandbox.tar.gz`;
+    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.25.0/9b3d6ba551f561a028f0216051e031bc2ba0c6b7/near-sandbox.tar.gz`;
 }
 exports.AWSUrl = AWSUrl;
 function getBinary(name = "near-sandbox") {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sandbox",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "CLI tool for testing NEAR smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -14,7 +14,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.25.0/9b3d6ba551f561a028f0216051e031bc2ba0c6b7/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/57362268301554563c4f800af963a1270b3d5283/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -14,7 +14,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/2c9375ee5ee307c2ce870c7dbd25eefd84fe8c36/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.25.0/9b3d6ba551f561a028f0216051e031bc2ba0c6b7/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {


### PR DESCRIPTION
This includes changes from https://github.com/near/sandbox/pull/28 to point to a closer nearcore binary.

@itegulov We have to point to master for the latest release since MacOS doesn't have a tagged binary quite yet, since this change was only recently done https://github.com/near/nearcore/pull/6426 and a new release (1.26 and up) will have to be made for it to be accessible