### PR TITLE
release: bump sandbox to 1.26.0

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -8,7 +8,7 @@ pub mod sync;
 
 // The current version of the sandbox node we want to point to. This can be updated from
 // time to time, but probably should be close to when a release is made.
-const DEFAULT_SANDBOX_COMMIT_HASH: &str = "master/57362268301554563c4f800af963a1270b3d5283";
+const DEFAULT_SANDBOX_COMMIT_HASH: &str = "master/97c0410de519ecaca369aaee26f0ca5eb9e7de06";
 
 const fn platform() -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/npm/dist/getBinary.js
+++ b/npm/dist/getBinary.js
@@ -14,7 +14,7 @@ function getPlatform() {
 }
 function AWSUrl() {
     const [platform, arch] = getPlatform();
-    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/57362268301554563c4f800af963a1270b3d5283/near-sandbox.tar.gz`;
+    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/97c0410de519ecaca369aaee26f0ca5eb9e7de06/near-sandbox.tar.gz`;
 }
 exports.AWSUrl = AWSUrl;
 function getBinary(name = "near-sandbox") {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sandbox",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "CLI tool for testing NEAR smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -14,7 +14,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/57362268301554563c4f800af963a1270b3d5283/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/97c0410de519ecaca369aaee26f0ca5eb9e7de06/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {


### PR DESCRIPTION
This should address https://github.com/near/workspaces-js/issues/170 on the sandbox side. `workspaces-js` still needs to update to this sandbox version. The `workspaces-rs` doesn't have to quite yet since it's just overriding to this version anyways