### PR TITLE
add arm64 architecture case for M1 pro

### DIFF
--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -6,7 +6,7 @@ function getPlatform() {
   const type = os.type();
   const arch = os.arch();
 
-  if ((type === "Linux" || type === "Darwin") && arch === "x64") {
+  if ((type === "Linux" || type === "Darwin") && (arch === "x64" || arch === "arm64")) {
     return [type, "x86_64"];
   }
   throw new Error(`Unsupported platform: ${type} ${arch}`);


### PR DESCRIPTION
I am using M1 pro chip for using sandbox and it shows following error:

```
/Users/hyungsukkang/aurora/sandbox/npm/dist/getBinary.js:13
    throw new Error(`Unsupported platform: ${type} ${arch}`);
    ^

Error: Unsupported platform: Darwin arm64
    at getPlatform (/Users/hyungsukkang/aurora/sandbox/npm/dist/getBinary.js:13:11)
    at AWSUrl (/Users/hyungsukkang/aurora/sandbox/npm/dist/getBinary.js:16:30)
    at getBinary (/Users/hyungsukkang/aurora/sandbox/npm/dist/getBinary.js:27:19)
    at Object.<anonymous> (/Users/hyungsukkang/aurora/sandbox/npm/dist/install.js:4:27)
    at Module._compile (node:internal/modules/cjs/loader:1112:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1166:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:834:12)
    at Module.require (node:internal/modules/cjs/loader:1012:19)
    at require (node:internal/modules/cjs/helpers:102:18)

Node.js v18.4.0
error Command failed with exit code 1.
```

After returning x86_64 binary file to arm64 architecture setup, all tests were passed. I think it is ok to merge the code, but is there any other thing to be considered?