### PR TITLE
release(crate): 0.4.0-pre.1

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.4.0"
+version = "0.4.0-pre.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION
This is in preparation for release crate 0.4 with the M1 fix, which should come in the next patch version (0.4.1).

The biggest change is that we're no longer gonna have a compiler error when building on a non-supported platform, so that we can use the utility functions to call into an external provided binary if needed to. `workspaces-rs` shouldn't be affected too much by this since we're still gonna error out with `Unsupported platform` during build-time if the platform isn't supported or if the binary provided is wrong. Also, added a fix to not install when supplying incorrect path to the sandbox binary

Also, @austinabell do you think this should be pre-release? This crate isn't in the major versions yet so I feel it's not needed