### PR TITLE
release: crate 0.4.1 and npm package 0.0.13

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -8,7 +8,8 @@ pub mod sync;
 
 // The current version of the sandbox node we want to point to. This can be updated from
 // time to time, but probably should be close to when a release is made.
-const DEFAULT_SANDBOX_COMMIT_HASH: &str = "master/13a66dda709a4148f6395636914dca2a55df1390";
+// Currently pointing to nearcore on Aug 12, 2022
+const DEFAULT_SANDBOX_COMMIT_HASH: &str = "master/dbb72eba04dcdda3fc97953af8be9870314e53dc";
 
 const fn platform() -> Option<&'static str> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/npm/dist/getBinary.js
+++ b/npm/dist/getBinary.js
@@ -16,7 +16,7 @@ function getPlatform() {
 }
 function AWSUrl() {
     const [platform, arch] = getPlatform();
-    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/13a66dda709a4148f6395636914dca2a55df1390/near-sandbox.tar.gz`;
+    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/dbb72eba04dcdda3fc97953af8be9870314e53dc/near-sandbox.tar.gz`;
 }
 exports.AWSUrl = AWSUrl;
 function getBinary(name = "near-sandbox") {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sandbox",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "CLI tool for testing NEAR smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sandbox",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "CLI tool for testing NEAR smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -17,7 +17,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/13a66dda709a4148f6395636914dca2a55df1390/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/dbb72eba04dcdda3fc97953af8be9870314e53dc/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {


### PR DESCRIPTION
This fixes inconsistent overflowing errors on nearcore binaries while on macOS