### PR TITLE
fix: Prevent installation from colliding when called concurrently into `ensure_sandbox_bin`

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1"
 async-process = "1.3.0"
 binary-install = "0.0.2"
 chrono = "0.4"
+fs2 = "0.4"
 hex = "0.3"
 home = "0.5.3"
 

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -43,7 +43,7 @@ fn bin_url(version: &str) -> Option<String> {
     ))
 }
 
-pub fn download_path() -> PathBuf {
+fn download_path() -> PathBuf {
     if cfg!(feature = "global_install") {
         let mut buf = home::home_dir().expect("could not retrieve home_dir");
         buf.push(".near");
@@ -126,6 +126,7 @@ pub fn ensure_sandbox_bin() -> anyhow::Result<PathBuf> {
     let mut bin_path = bin_path()?;
     if let Some(lockfile) = installable(&bin_path)? {
         bin_path = install()?;
+        println!("Installed near-sandbox into {}", bin_path.to_str().unwrap());
         std::env::set_var("NEAR_SANDBOX_BIN_PATH", bin_path.as_os_str());
         lockfile.unlock()?;
     }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sandbox",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "CLI tool for testing NEAR smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sandbox",
-  "version": "0.0.14",
+  "version": "0.0.13",
   "description": "CLI tool for testing NEAR smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
For context and should resolve https://github.com/near/workspaces-rs/issues/193 after making it into workspaces-rs side.

After this PR, `ensure_sandbox_bin` will check if the binary is installable via a lockfile, so we don't run into any concurrent installs.