### PR TITLE
speed things up

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -160,7 +160,7 @@ pub fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
     let home_dir = home_dir.as_ref().to_str().unwrap();
     Command::new(bin_path)
         .envs(log_vars())
-        .args(&["--home", home_dir, "init"])
+        .args(&["--home", home_dir, "init", "--fast"])
         .spawn()
         .map_err(Into::into)
 }


### PR DESCRIPTION
This improves perfomance of `cargo run --example nft` from `7.3s` to `3.80s`