### PR TITLE
chore: point nearcore to latest release

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -9,10 +9,10 @@ use std::path::{Path, PathBuf};
 
 pub mod sync;
 
-// The current version of the sandbox node we want to point to. This can be updated from
-// time to time, but probably should be close to when a release is made.
-// Currently pointing to nearcore on Apr 3, 2023
-const DEFAULT_SANDBOX_COMMIT_HASH: &str = "master/d08187094a82b3bfab3b8b0fa076e71068f39cb7";
+// The current version of the sandbox node we want to point to.
+// Should be updated to the latest release of nearcore.
+// Currently pointing to nearcore@v1.35.0 released on Jul 25, 2023
+const DEFAULT_SANDBOX_COMMIT_HASH: &str = "1.35.0/1e781bcccfaeb9a4bb9531155193a459257afd8d";
 
 const fn platform() -> Option<&'static str> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/npm/dist/getBinary.js
+++ b/npm/dist/getBinary.js
@@ -17,7 +17,7 @@ function getPlatform() {
 }
 function AWSUrl() {
     const [platform, arch] = getPlatform();
-    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/d08187094a82b3bfab3b8b0fa076e71068f39cb7/near-sandbox.tar.gz`;
+    return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.35.0/1e781bcccfaeb9a4bb9531155193a459257afd8d/near-sandbox.tar.gz`;
 }
 exports.AWSUrl = AWSUrl;
 function getBinary(name = "near-sandbox") {

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -17,7 +17,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/master/d08187094a82b3bfab3b8b0fa076e71068f39cb7/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.35.0/1e781bcccfaeb9a4bb9531155193a459257afd8d/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {


### PR DESCRIPTION
Cleaner/Clearer to upgrade the hash commit to the latest release of nearcore instead of using arbitrary commits.
Pointing to https://github.com/near/nearcore/releases/tag/1.35.0