### PR TITLE
fix: version inconsistencies when using custom version

### DIFF
--- a/crate/src/sync.rs
+++ b/crate/src/sync.rs
@@ -28,7 +28,7 @@ pub fn init(home_dir: impl AsRef<Path>) -> anyhow::Result<Child> {
     let home_dir = home_dir.as_ref().to_str().unwrap();
     Command::new(bin_path)
         .envs(crate::log_vars())
-        .args(&["--home", home_dir, "init"])
+        .args(["--home", home_dir, "init"])
         .spawn()
         .map_err(Into::into)
 }


### PR DESCRIPTION
**Problem**
Recently, we initiated the use of a [custom version ](https://github.com/near/workspaces-rs/blob/be6afa421818272b6b3eb835264d5a97f00beb4b/workspaces/build.rs#L9) in the [workspace-rs](https://github.com/near/workspaces-rs) crate to fix one of the [issue](https://github.com/near/nearcore/issues/9143) nearcore had when building wasms with newer rust version. However, this change introduced an unintended consequence where other crates began encountering issues due to a mismatch in the sandbox version being utilized. The sandbox was defaulting to downloading this version https://github.com/near/sandbox/blob/ee06569991da4a3a69f3cc575715a3fdc06935da/crate/src/lib.rs#L15 instead of the newly specified custom version. The root cause of this mismatch seems to be originating from line https://github.com/near/sandbox/blob/ee06569991da4a3a69f3cc575715a3fdc06935da/crate/src/lib.rs#L126
</br>
**Solution**
This Pull Request proposes a solution to harmonize the versioning system by recording the **SANDBOX_VERSION** in a temporary file. This approach ensures that the version data can be retrieved and utilized consistently across different crates, thereby preventing the sandbox from defaulting to the original version. The temp file acts as a single source of truth for the version information and is referred by :https://github.com/near/sandbox/blob/ee06569991da4a3a69f3cc575715a3fdc06935da/crate/src/lib.rs#L123 

to determine the correct version to download and use.