### PR TITLE
fix: pin async-process version

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ Utility library for launching NEAR sandbox environments.
 
 [dependencies]
 anyhow = "1"
-async-process = "1"
+async-process = "1.7.0"
 binary-install = "0.2.0"
 chrono = "0.4"
 fs2 = "0.4"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ Utility library for launching NEAR sandbox environments.
 
 [dependencies]
 anyhow = "1"
-async-process = "1.7.0"
+async-process = "=1.7.0"
 binary-install = "0.2.0"
 chrono = "0.4"
 fs2 = "0.4"


### PR DESCRIPTION
There's was a [build issue](https://github.com/near/near-workspaces-rs/issues/312) with linux that started after the time `async-process v1.8.0` was [released](https://github.com/smol-rs/async-process/releases/tag/v1.8.0). This PR pins the package to the previous version. The issue concerned is left as a todo for later investigation/work.