### PR TITLE
fix: pin async-process crate

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ Utility library for launching NEAR sandbox environments.
 
 [dependencies]
 anyhow = "1"
-async-process = "1"
+async-process = "=1.7.0"
 binary-install = "0.2.0"
 chrono = "0.4"
 fs2 = "0.4"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,8 @@ Utility library for launching NEAR sandbox environments.
 
 [dependencies]
 anyhow = "1"
-async-process = "=1.7.0"
+# The version is pinned to <=1.7.0 because of the following issue: https://github.com/near/near-workspaces-rs/issues/312
+async-process = "<=1.7.0"
 binary-install = "0.2.0"
 chrono = "0.4"
 fs2 = "0.4"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -10,7 +10,7 @@ Utility library for launching NEAR sandbox environments.
 
 [dependencies]
 anyhow = "1"
-# The version is pinned to <=1.7.0 because of the following issue: https://github.com/near/near-workspaces-rs/issues/312
+# The version is pinned to <=1.7.0 because of the following issue: https://github.com/smol-rs/async-process/issues/55
 async-process = "<=1.7.0"
 binary-install = "0.2.0"
 chrono = "0.4"


### PR DESCRIPTION
There's was a [build issue](https://github.com/near/near-workspaces-rs/issues/312) with linux that started after the time `async-process v1.8.0` was [released](https://github.com/smol-rs/async-process/releases/tag/v1.8.0). This PR pins the package to the previous version. The issue concerned is left as a todo for later investigation/work.

`async-process` Issue: https://github.com/smol-rs/async-process/issues/55 