### PR TITLE
Update nearcore version to post v1.37

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -11,8 +11,8 @@ pub mod sync;
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v1.35.0 released on Jul 25, 2023
-pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "1.35.0/1e781bcccfaeb9a4bb9531155193a459257afd8d";
+// Currently pointing to nearcore@v1.38.0 released on March 18, 2024
+pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "1.38.0/aac5e42fe8975e27faca53e31f53f9c67a5b4e35";
 
 const fn platform() -> Option<&'static str> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -17,7 +17,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.37.3/b341e778154917aa7ab19f79c8d59a794ead320a/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.38.0/aac5e42fe8975e27faca53e31f53f9c67a5b4e35/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -17,7 +17,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.35.0/1e781bcccfaeb9a4bb9531155193a459257afd8d/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.37.3/b341e778154917aa7ab19f79c8d59a794ead320a/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {


### PR DESCRIPTION
## Context
Update nearcore to v1.37.3 that adds `send_tx` RPC method and a some other features. This allows for `near-workspaces-js`, `near-api-js` and other dependants of near-sandbox to be compatible with the new RPC methods.

## Issue
Currently near-api-js uses near-workspaces-js to run tests in a sandboxed environment. The latest PR updates the RPC logic to use `send_tx`. However the [CI checks](https://github.com/near/near-api-js/actions/runs/8247720893/job/22556700185#step:8:284) fails because: `[-32601] Method not found: send_tx`.

## Next steps
After this PR is updated, a subsequent PR will be opened in `near-workspaces-js` to bump the version, so that near-api-js can pull it.
